### PR TITLE
[Styled] 프로필 썸네일 컴포넌트 medium 사이즈 추가 #11

### DIFF
--- a/src/Components/Common/ProfileThumb/ProfileThumb.style.jsx
+++ b/src/Components/Common/ProfileThumb/ProfileThumb.style.jsx
@@ -9,6 +9,12 @@ const setSize = size => {
         height: 36px;
       `;
 
+    case 'medium':
+      return css`
+        width: 42px;
+        height: 42px;
+      `;
+
     default:
       return css`
         width: 110px;


### PR DESCRIPTION
### 📝 무엇을 위한 PR인가요?

- [x] 스타일 : 프로필 썸네일 컴포넌트 medium 사이즈 추가


### ♻️ 작업내역 / 변경사항

42x42 사이즈 추가했습니다
size 에 medium 전달 시 사용 가능합니다

### 🖼 결과

![image](https://user-images.githubusercontent.com/46313348/207512129-b4498bdf-21c1-4cdd-97fb-819250e3c779.png)

### 💡 이슈 번호
closed #11 