### PR TITLE
[Styled] 프로필 썸네일 컴포넌트 large 사이즈 추가

### DIFF
--- a/src/Components/Common/ProfileThumb/ProfileThumb.style.jsx
+++ b/src/Components/Common/ProfileThumb/ProfileThumb.style.jsx
@@ -15,6 +15,12 @@ const setSize = size => {
         height: 42px;
       `;
 
+    case 'large':
+      return css`
+        width: 50px;
+        height: 50px;
+      `;
+
     default:
       return css`
         width: 110px;


### PR DESCRIPTION
### 📝 무엇을 위한 PR인가요?

- [x] 스타일 : 프로필 썸네일 컴포넌트 large 사이즈 추가

### ♻️ 작업내역 / 변경사항

50x50 사이즈 추가했습니다
size 에 large 전달 시 사용 가능합니다

### 🖼 결과

![image](https://user-images.githubusercontent.com/46313348/207634685-bef9d04c-e520-4f11-b987-b7785623e834.png)

### 💡 이슈 번호
closed #19 