### PR TITLE
[Styled] 프로필 설정 페이지 스타일링 수정

### DIFF
--- a/src/Pages/Signup/Profile/ProfileSet.jsx
+++ b/src/Pages/Signup/Profile/ProfileSet.jsx
@@ -1,8 +1,7 @@
 import React from 'react';
 import { ProfileWrapper, ProfileTitle, InputWrapper, Label, Input, DescText, InpImg } from './ProfileSet.style';
 import Button from '../../../Components/Common/Button/Button';
-import ProfileThumb from '../../../Components/Common/ProfileThumb/ProfileThumb';
-import BtnUpload from '../../../Components/Common/BtnUpload/BtnUpload';
+import ProfileImg from '../../../Components/ProfileEdit/ProfileImg/ProfileImg';
 
 export default function ProfileSet() {
   return (
@@ -11,8 +10,7 @@ export default function ProfileSet() {
       <DescText>나중에 언제든지 변경 할 수 있습니다.</DescText>
       <form>
         <InpImg>
-          <ProfileThumb size={'xlarge'} />
-          <BtnUpload />
+          <ProfileImg />
         </InpImg>
         <InputWrapper>
           <Label htmlFor='userName'>사용자 이름</Label>

--- a/src/Pages/Signup/Profile/ProfileSet.style.jsx
+++ b/src/Pages/Signup/Profile/ProfileSet.style.jsx
@@ -6,6 +6,8 @@ export const ProfileWrapper = styled.div`
   display: flex;
   flex-direction: column;
   align-items: center;
+  height: 100%;
+  overflow-y: auto;
 `;
 
 export const ProfileTitle = styled.h1`

--- a/src/Pages/Signup/Profile/ProfileSet.style.jsx
+++ b/src/Pages/Signup/Profile/ProfileSet.style.jsx
@@ -1,12 +1,11 @@
 import styled from 'styled-components';
 
-export const ProfileWrapper = styled.section`
+export const ProfileWrapper = styled.div`
   width: 100%;
   overflow: hidden;
   display: flex;
   flex-direction: column;
   align-items: center;
-  height: calc(100% - 108px);
 `;
 
 export const ProfileTitle = styled.h1`
@@ -49,7 +48,6 @@ export const InputWrapper = styled.div`
 `;
 
 export const InpImg = styled.div`
-  position: relative;
   display: flex;
   justify-content: center;
   margin-bottom: 30px;


### PR DESCRIPTION
### 📝 무엇을 위한 PR인가요?
- [x] 스타일 : 프로필 설정에 스크롤 제거


### ♻️ 작업내역 / 변경사항

1. 스크롤 생성으로 인해 ProfileSet.style - ProfileWrapper를 Section 태그로 변경
2. 레이아웃에서 sectiion 태그로 전달되는 스타일 요소를 안받게 되었습니다.
3. ProfileImg 컴포넌트로 수정
4. 프로필 설정 페이지 스크롤 생성

### 🖼 결과
<img width="853" alt="스크린샷 2022-12-24 19 14 28" src="https://user-images.githubusercontent.com/78248971/209431500-ae122bb4-ae9a-43b7-b74a-034cb7bf5129.png">

✴︎ 회원가입 레이아웃에 대한 컨펌이 필요합니다!

### 💡 이슈 번호