### PR TITLE
[Feat] 판매 중인 상품 불러오기 및 프로필 페이지에 적용

### DIFF
--- a/src/API/api.js
+++ b/src/API/api.js
@@ -124,3 +124,13 @@ export const uploadPost = async post => {
     throw new Error(error);
   }
 };
+
+export const getProduct = async accountname => {
+  try {
+    const response = await instance.get(`/product/${accountname}`);
+
+    return response.data.product;
+  } catch (error) {
+    throw new Error(error);
+  }
+};

--- a/src/Components/Product/Product.jsx
+++ b/src/Components/Product/Product.jsx
@@ -1,20 +1,25 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import { ProductList, ProductListWrapper, ProductWrapper } from './Product.style';
 import ProductItem from './ProductItem/ProductItem';
+import { getProduct } from './../../API/api';
 
-export default function Product() {
+export default function Product({ accountName, tagList }) {
+  const [productList, setProductList] = useState([]);
+
+  useEffect(() => {
+    getProduct(accountName).then(response => {
+      setProductList(response);
+    });
+  }, []);
+
   return (
     <ProductWrapper>
       <h3>판매 중인 상품</h3>
       <ProductListWrapper>
         <ProductList>
-          <ProductItem />
-          <ProductItem />
-          <ProductItem />
-          <ProductItem />
+          {productList && productList.map(product => <ProductItem key={product.id} productData={product} />)}
         </ProductList>
       </ProductListWrapper>
     </ProductWrapper>
   );
 }
-//  여기 페이지신분이 값 받아서 map 활용

--- a/src/Components/Product/Product.jsx
+++ b/src/Components/Product/Product.jsx
@@ -8,7 +8,13 @@ export default function Product({ accountName, tagList }) {
 
   useEffect(() => {
     getProduct(accountName).then(response => {
-      setProductList(response);
+      if (tagList) {
+        const filtered = response.filter(item => tagList.includes(item.itemName));
+
+        setProductList(filtered);
+      } else {
+        setProductList(response);
+      }
     });
   }, []);
 

--- a/src/Components/Product/ProductItem/ProductItem.jsx
+++ b/src/Components/Product/ProductItem/ProductItem.jsx
@@ -1,14 +1,14 @@
 import React from 'react';
 import { ImageWrapper, ProductItemWrapper, ProductName, ProductPrice } from './ProductItem.style';
 
-export default function ProductItem() {
+export default function ProductItem({ productData }) {
   return (
     <ProductItemWrapper>
       <ImageWrapper>
-        <img src='https://cdn.pixabay.com/photo/2018/05/26/10/54/strawberries-3431122_960_720.jpg' alt='' />
+        <img src={`https://mandarin.api.weniv.co.kr/${productData.itemImage}`} alt={productData.itemName} />
       </ImageWrapper>
-      <ProductName>애월읍 노지 감귤 10kg 애월읍 노지 감귤 10kg</ProductName>
-      <ProductPrice>35,000원</ProductPrice>
+      <ProductName>{productData.itemName}</ProductName>
+      <ProductPrice>{productData.price.toLocaleString()}원</ProductPrice>
     </ProductItemWrapper>
   );
 }

--- a/src/Components/Product/ProductItem/ProductItem.style.jsx
+++ b/src/Components/Product/ProductItem/ProductItem.style.jsx
@@ -1,7 +1,9 @@
 import styled from 'styled-components';
 
 export const ProductItemWrapper = styled.li`
-  width: 35.897vw;
+  flex: 0 0 auto;
+  width: 35.897%;
+  min-width: 140px;
 `;
 
 export const ImageWrapper = styled.div`

--- a/src/Pages/Main/Profile/UserProfile/UserProfile.jsx
+++ b/src/Pages/Main/Profile/UserProfile/UserProfile.jsx
@@ -19,6 +19,7 @@ import PostCard from '../../../../Components/Common/PostCard/PostCard';
 import Modal from '../../../../Components/Common/Modal/Modal';
 
 export default function UserProfile() {
+  const userId = localStorage.getItem('user ID');
   const { isModal } = useOutletContext();
   const listObj = [
     {
@@ -66,7 +67,7 @@ export default function UserProfile() {
             </Link>
           </ButtonWrapper>
         </ProfileWrapper>
-        <Product />
+        <Product accountName={userId} />
         <GetPost />
         <PostCard />
       </UserProfileWrapper>


### PR DESCRIPTION
### 📝 무엇을 위한 PR인가요?

- [x] 기능 추가 : 판매 중인 상품 불러오기 및 프로필 페이지에 적용

### ♻️ 작업내역 / 변경사항

1. 판매 중인 상품 목록 api 호출
2. 재료가 존재하면 필터링되는 기능 추가
3. ProductItem 컴포넌트 최소 가로 사이즈 조절
4. 판매 중인 상품 컴포넌트 프로필 페이지에 적용

※ 게시글 상세 페이지가 작업 완료되면 컴포넌트 추가하겠습니다~!

### 🖼 결과

![image](https://user-images.githubusercontent.com/46313348/209676140-4bcd5513-bf2a-4771-b665-c25ca6b02a4a.png)

### 💡 이슈 번호
#95 