### PR TITLE
[Fix] 맥북에서 재료가 두 번 입력되는 이슈 수정

### DIFF
--- a/src/Components/PostEdit/PostTag/PostTag.jsx
+++ b/src/Components/PostEdit/PostTag/PostTag.jsx
@@ -10,7 +10,7 @@ export default function PostTag({ tagList, setTagList }) {
   };
 
   const onKeyDownHandler = e => {
-    if (e.key === 'Enter') {
+    if (!e.nativeEvent.isComposing && e.key === 'Enter') {
       e.preventDefault();
 
       if (e.target.value.length === 0) return;


### PR DESCRIPTION
### 📝 무엇을 위한 PR인가요?

- [x] 기능 추가 : 맥북에서 재료가 두 번 입력되는 이슈 수정

### ♻️ 작업내역 / 변경사항

1. isComposing 상태가 아닌 경우에만 동작하도록 수정

### 🖼 결과

<img width="431" alt="스크린샷 2022-12-28 오전 11 31 04" src="https://user-images.githubusercontent.com/46313348/209748047-86afdfc2-87a7-4dae-97a4-b9891e8b442f.png">

### 💡 이슈 번호
close #98 