### PR TITLE
[Fix] 게시물 이미지 프리뷰 src 포맷 변경

### DIFF
--- a/src/Components/PostEdit/PostImg/PostImg.jsx
+++ b/src/Components/PostEdit/PostImg/PostImg.jsx
@@ -8,7 +8,7 @@ export default function PostImg({ response, deleteFile }) {
       {response &&
         response.map(file => (
           <PostImgItem key={crypto.randomUUID()}>
-            <img src={`https://mandarin.api.weniv.co.kr/${file}`} alt='' />
+            <img src={URL.createObjectURL(file)} alt='' />
             <BtnDelete onClick={() => deleteFile(file)} type='button'>
               <img src={IconDelete} alt='이미지 삭제' />
             </BtnDelete>


### PR DESCRIPTION
### 📝 무엇을 위한 PR인가요?

- [x] 기능 추가 : 게시물 이미지 프리뷰 src 포맷 변경

### ♻️ 작업내역 / 변경사항

1. 이미지 프리뷰 src 표현 방법 URL.createObjectURL 사용하도록 수정

### 🖼 결과

![image](https://user-images.githubusercontent.com/46313348/209811103-f953e708-d4ab-495a-8529-4e94af73ad2a.png)

### 💡 이슈 번호
close #107 