### PR TITLE
[Fix] 탭메뉴에서 로그인 한 유저의 프로필로 연결

### DIFF
--- a/src/Components/Common/TabMenu/TabMenu.jsx
+++ b/src/Components/Common/TabMenu/TabMenu.jsx
@@ -4,9 +4,10 @@ import { TabMenuWrapper } from './TabMenu.style';
 
 export default function TabMenu() {
   const { pathname } = useLocation();
+  const accountName = localStorage.getItem('user ID');
 
   return (
-    <TabMenuWrapper type={pathname}>
+    <TabMenuWrapper type={pathname.split('/')[1]}>
       <Link to='/main' className='home'>
         홈
       </Link>
@@ -16,7 +17,7 @@ export default function TabMenu() {
       <Link to='/post/upload' className='post'>
         게시물 작성
       </Link>
-      <Link to='/profile' className='profile'>
+      <Link to={`/profile/${accountName}`} className='profile'>
         프로필
       </Link>
     </TabMenuWrapper>

--- a/src/Components/Common/TabMenu/TabMenu.style.jsx
+++ b/src/Components/Common/TabMenu/TabMenu.style.jsx
@@ -9,7 +9,7 @@ import iconProfileFill from '../../../Assets/Icons/icon_profile_fill.png';
 
 const setActiveIcon = type => {
   switch (type) {
-    case '/chat':
+    case 'chat':
       return css`
         &.chat {
           color: ${({ theme }) => theme.colors.primary};
@@ -19,7 +19,7 @@ const setActiveIcon = type => {
           }
         }
       `;
-    case '/profile':
+    case 'profile':
       return css`
         &.profile {
           color: ${({ theme }) => theme.colors.primary};


### PR DESCRIPTION
### 📝 무엇을 위한 PR인가요?

- [x] 기능 추가 : 탭메뉴에서 로그인 한 유저의 프로필로 연결

### ♻️ 작업내역 / 변경사항

1. 탭메뉴에서 프로필 클릭 시 로그인 한 유저의 프로필로 연결되도록 수정
2. 변경 된 url에 맞추어 색상 바뀌게 수정

### 🖼 결과
![image](https://user-images.githubusercontent.com/46313348/209812646-3e14cb8b-8913-4272-8175-6cb74331e204.png)

### 💡 이슈 번호
close #109