### PR TITLE
[Fix] 프로필 페이지 내 해당 유저가 판매 중인 상품만 보이도록 수정2 (state 이름 반영)

### DIFF
--- a/src/Pages/Main/Profile/UserProfile/UserProfile.jsx
+++ b/src/Pages/Main/Profile/UserProfile/UserProfile.jsx
@@ -75,8 +75,7 @@ export default function UserProfile() {
             </Link>
           </ButtonWrapper>
         </ProfileWrapper>
-        <Product accountName={userId} />
-        <Product />
+        <Product accountName={name} />
         <GetPost userId={name} />
       </UserProfileWrapper>
     </>


### PR DESCRIPTION
### 📝 무엇을 위한 PR인가요?

- [x] 버그 수정 :  프로필 페이지 내 해당 유저가 판매 중인 상품만 보이도록 수정2

### ♻️ 작업내역 / 변경사항

1. 프로필 페이지 내 해당 유저가 판매 중인 상품만 보이도록 수정

### 🖼 결과


### 💡 이슈 번호