### PR TITLE
[Feat] 상대 / 자신 프로필 구분해서 보여주는 기능 구현

### DIFF
--- a/src/Components/Common/PostCard/PostCard.jsx
+++ b/src/Components/Common/PostCard/PostCard.jsx
@@ -6,15 +6,24 @@ import Modal from '../Modal/Modal';
 import ReactionSection from '../../Reactions/ReactionSection';
 
 export default function PostCard({ accountname, username, image, postContent, postImg, uploadDate }) {
+  const localID = localStorage.getItem('user ID');
   const [isModal, setIsModal] = useState(false);
-  const listObj = [
-    {
-      name: '삭제',
-      func: () => console.log('삭제'),
-    },
-    { name: '수정', func: () => console.log('수정') },
-  ];
 
+  const listObj =
+    localID === accountname
+      ? [
+          {
+            name: '삭제',
+            func: () => console.log('삭제'),
+          },
+          { name: '수정', func: () => console.log('수정') },
+        ]
+      : [
+          {
+            name: '신고하기',
+            func: () => console.log('신고하기'),
+          },
+        ];
   const getFormatDate = date => {
     const year = date.getFullYear();
     const month = 1 + date.getMonth();

--- a/src/Pages/Main/Profile/UserProfile/UserProfile.jsx
+++ b/src/Pages/Main/Profile/UserProfile/UserProfile.jsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { json, Link } from 'react-router-dom';
+import { json, Link, useNavigate, useParams } from 'react-router-dom';
 import {
   ProfileWrapper,
   Follow,
@@ -19,15 +19,22 @@ import { getProfile } from '../../../../API/api';
 
 export default function UserProfile() {
   // 유저 프로필 정보 가져오기
+  const navigate = useNavigate();
   const [userId, setUserId] = useState('');
   const [name, setName] = useState('');
   const [introduce, setIntroduce] = useState('');
   const [profileImg, setProfileImg] = useState('');
   const [follower, setFollower] = useState('');
   const [following, setFollowing] = useState('');
+  const [isOwn, setIsOwn] = useState(false);
+  const { accountName } = useParams();
+  const localID = localStorage.getItem('user ID');
+  const ownCheck = (urlID, ownID) => {
+    urlID === ownID ? setIsOwn(true) : setIsOwn(false);
+  };
 
   useEffect(() => {
-    getProfile(process.env.REACT_APP_ACCOUNT_NAME).then(response => {
+    getProfile(accountName).then(response => {
       const { accountname, username, intro, image, followerCount, followingCount } = response.profile;
 
       setUserId(prev => username);
@@ -36,10 +43,11 @@ export default function UserProfile() {
       setProfileImg(prev => image);
       setFollower(prev => followerCount);
       setFollowing(prev => followingCount);
+      ownCheck(accountName, localID);
       console.log(response);
     });
   }, []);
-
+  console.log(isOwn);
   return (
     <>
       <UserProfileWrapper>
@@ -65,14 +73,28 @@ export default function UserProfile() {
             <p>{introduce}</p>
           </Profile>
           <ButtonWrapper>
-            <Link to='/chat'>
-              <img src={iconChat} alt='채팅하기 버튼' />
-            </Link>
-            <Button className='medium' disabled={false} content='팔로우' />
-            {/* Share 컴포넌트로 대체할 것임.. */}
-            <Link to='/chat'>
-              <img src={iconShare} alt='채팅하기 버튼' />
-            </Link>
+            {isOwn ? (
+              <>
+                <Button
+                  className='small'
+                  disabled={false}
+                  onClick={() => navigate(`/profile/${accountName}/edit`)}
+                  content='프로필 수정'
+                />
+                <Button className='small' disabled={false} onClick={() => navigate('/product')} content='상품 등록' />
+              </>
+            ) : (
+              <>
+                <Link to='/chat'>
+                  <img src={iconChat} alt='채팅하기 버튼' />
+                </Link>
+                <Button className='medium' disabled={false} content='팔로우' />
+
+                <Link to='/chat'>
+                  <img src={iconShare} alt='채팅하기 버튼' />
+                </Link>
+              </>
+            )}
           </ButtonWrapper>
         </ProfileWrapper>
         <Product accountName={name} />

--- a/src/Routes/Router.jsx
+++ b/src/Routes/Router.jsx
@@ -70,7 +70,7 @@ export default function Router() {
 
             <Route path='/postid' element={<Comment />} />
 
-            <Route path='/profile/:accountname'>
+            <Route path='/profile/:accountName'>
               <Route index element={<UserProfile />} />
               <Route path='edit' element={<ProfileEdit />} />
               <Route path='followers' element={<Followers />} />


### PR DESCRIPTION
### 📝 무엇을 위한 PR인가요?

- [x] 기능 추가 : 유저에 따라서 프로필을 스위칭 해주는 기능 구현

### ♻️ 작업내역 / 변경사항

1. url에서 받아오는 id와 로컬 스토리지에 저장되어있는 id를 비교해준다.
2. 그에 따라서 맞는 userProfile을 보여준다.


### 🖼 결과
<img width="343" alt="스크린샷 2022-12-29 17 00 27" src="https://user-images.githubusercontent.com/78248971/209921419-56f98890-a16a-4d04-aa5e-8bb13eb49f38.png">
<img width="500" alt="스크린샷 2022-12-29 17 01 19" src="https://user-images.githubusercontent.com/78248971/209921525-f46be52b-b9ff-4b95-b9b0-84776fd259e0.png">

<img width="470" alt="스크린샷 2022-12-29 17 00 46" src="https://user-images.githubusercontent.com/78248971/209921457-73ed7b84-b68b-41dd-bbb9-bdd9122053bd.png">
<img width="500" alt="스크린샷 2022-12-29 17 01 00" src="https://user-images.githubusercontent.com/78248971/209921488-72c3a10b-939b-4203-86f2-89264c316fc2.png">


### 💡 이슈 번호