### PR TITLE
[Fix] 홈피드 이미지 안 나오는 이슈

### DIFF
--- a/src/Pages/Main/HomeFeed/HomeFeed.jsx
+++ b/src/Pages/Main/HomeFeed/HomeFeed.jsx
@@ -23,13 +23,15 @@ export default function HomeFeed() {
     <HomeFeedWrapper length={feedList.length}>
       {feedList.length ? (
         feedList.map(feed => {
+          const postImg = feed.image.split('co.kr/')[1];
+
           return (
             <PostCard
               accountname={feed.author.accountname}
               username={feed.author.username}
               image={feed.author.image}
               postContent={feed.content}
-              postImg={feed.image}
+              postImg={postImg}
               uploadDate={feed.updatedAt}
             />
           );

--- a/src/Pages/Main/HomeFeed/HomeFeed.jsx
+++ b/src/Pages/Main/HomeFeed/HomeFeed.jsx
@@ -33,6 +33,7 @@ export default function HomeFeed() {
               postContent={feed.content}
               postImg={postImg}
               uploadDate={feed.updatedAt}
+              key={crypto.randomUUID()}
             />
           );
           // <p>d</p>


### PR DESCRIPTION
### 📝 무엇을 위한 PR인가요?

- [x] 버그 수정 : 홈피드 이미지 안 나오는 이슈 해결

### ♻️ 작업내역 / 변경사항

1. 이미지 링크에서 파일명만 분리하여 props로 전달
2. PostCard 에 key 값 추가

### 🖼 결과

![image](https://user-images.githubusercontent.com/46313348/209921643-acc0a355-d2c5-4653-9072-2d551afc0d9a.png)

### 💡 이슈 번호
close #128