### PR TITLE
[Feat] 채팅 리스트 페이지 구현

### DIFF
--- a/src/Pages/Main/Chat/ChatList/ChatItem/ChatItem.jsx
+++ b/src/Pages/Main/Chat/ChatList/ChatItem/ChatItem.jsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import { useNavigate } from 'react-router-dom';
+import {
+  ChatItemWrapper,
+  ProfileImgWrapper,
+  Dot,
+  ItemContent,
+  ChatItemTime,
+  UserNameWrapper,
+  ItemContentText,
+} from './ChatItem.style';
+import ProfileThumb from '../../../../../Components/Common/ProfileThumb/ProfileThumb';
+
+export default function ChatItem({ userId, userName, chatContent = '대화내용이 없습니다.', userImg, userState }) {
+  const navigate = useNavigate();
+
+  return (
+    <ChatItemWrapper onClick={() => navigate(`${userId}`, { state: { userName, userImg } })}>
+      <ProfileImgWrapper>
+        <ProfileThumb size='medium' src={userImg} />
+        {userState ? <Dot /> : null}
+      </ProfileImgWrapper>
+      <ItemContent>
+        <UserNameWrapper>{userName}</UserNameWrapper>
+        <ItemContentText>{chatContent}</ItemContentText>
+      </ItemContent>
+      <ChatItemTime datetime='2020-10-25'>2020.10.25</ChatItemTime>
+    </ChatItemWrapper>
+  );
+}

--- a/src/Pages/Main/Chat/ChatList/ChatItem/ChatItem.style.jsx
+++ b/src/Pages/Main/Chat/ChatList/ChatItem/ChatItem.style.jsx
@@ -1,0 +1,49 @@
+import styled from 'styled-components';
+
+export const ChatItemWrapper = styled.li`
+  display: flex;
+  gap: 12px;
+  position: relative;
+  min-width: 0;
+`;
+
+export const ProfileImgWrapper = styled.div`
+  flex: 0 0 auto;
+  position: relative;
+`;
+
+export const Dot = styled.div`
+  position: absolute;
+  left: 0;
+  top: 0;
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  background-color: #f26e22;
+`;
+
+export const ItemContent = styled.div`
+  position: relative;
+  width: calc(100% - 125px);
+  display: flex;
+  flex-direction: column;
+  justify-content: space-around;
+`;
+
+export const UserNameWrapper = styled.strong`
+  font-size: ${({ theme }) => theme.fontSizes.base};
+  font-weight: 700;
+`;
+
+export const ItemContentText = styled.p`
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  font-size: ${({ theme }) => theme.fontSizes.sm};
+`;
+
+export const ChatItemTime = styled.div`
+  align-self: center;
+  color: ${({ theme }) => theme.colors.background};
+  font-size: ${({ theme }) => theme.fontSizes.sm};
+`;

--- a/src/Pages/Main/Chat/ChatList/ChatList.jsx
+++ b/src/Pages/Main/Chat/ChatList/ChatList.jsx
@@ -1,18 +1,45 @@
-import React, { useState } from 'react';
-import Modal from '../../../../Components/Common/Modal/Modal';
+import React, { useState, useEffect } from 'react';
+import ChatItem from './ChatItem/ChatItem';
+import { getFollowingList, getFollowerList } from '../../../../API/api';
+import { ChatingWrapper, ChatListWrapper } from './ChatList.style';
 
 export default function ChatList() {
-  const [isModal, setIsModal] = useState(false);
-  const listObj = [
-    {
-      name: '설정 및 개인정보',
-      func: () => console.log('설정 및 개인정보'),
-    },
-    {
-      name: '로그아웃',
-      func: () => console.log('로그아웃'),
-    },
-  ];
+  const [friends, setFriends] = useState([]);
+  const [followList, setFollowList] = useState([]);
+  const [followingList, setFollowingList] = useState([]);
 
-  return <>{isModal && <Modal listObj={listObj} />}</>;
+  useEffect(() => {
+    getFollowingList().then(response => setFollowList(prev => response));
+    getFollowerList().then(response => setFollowingList(prev => response));
+  }, []);
+  useEffect(() => {
+    setFriends(prev => [...followList, ...followingList]);
+  }, [followList, followingList]);
+
+  const userChatMember = friends.filter((one, i) => {
+    return (
+      friends.findIndex(two => {
+        return one.accountname === two.accountname;
+      }) === i
+    );
+  });
+
+  return (
+    <>
+      <ChatingWrapper>
+        <ChatListWrapper>
+          {userChatMember &&
+            userChatMember.map(member => (
+              <ChatItem
+                userId={member.accountname}
+                userName={member.username}
+                userImg={member.image}
+                userState={Math.floor(Math.random() * 2)}
+                key={crypto.randomUUID()}
+              />
+            ))}
+        </ChatListWrapper>
+      </ChatingWrapper>
+    </>
+  );
 }

--- a/src/Pages/Main/Chat/ChatList/ChatList.style.jsx
+++ b/src/Pages/Main/Chat/ChatList/ChatList.style.jsx
@@ -1,0 +1,11 @@
+import styled from 'styled-components';
+
+export const ChatingWrapper = styled.section`
+  padding: 24px 16px;
+`;
+
+export const ChatListWrapper = styled.ul`
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+`;


### PR DESCRIPTION
### 📝 무엇을 위한 PR인가요?

- [x] 기능 추가 : 채팅 리스트 페이지에 필요한 컴포넌트 구현
- [x] 기능 추가 : 채팅 리스트에 보여줄 user를 서버 통신을 통해 가져와서 리스트에 보여주는 기능 구현
- [x] 스타일 : 채팅 리스트 페이지 스타일링

### ♻️ 작업내역 / 변경사항

1. ChatLIst 페이지 구현

2. 리스트에 사용되는 ChatItem 컴포넌트 구현
3. user의 follower와 following 유저의 정보를 가져와서 리스트에 보여주었습니다.

### 🖼 결과

<img width="822" alt="스크린샷 2022-12-30 05 02 02" src="https://user-images.githubusercontent.com/78248971/210005980-b377d7b5-3ae6-4434-a837-9e73d81096fb.png">


### 💡 이슈 번호
close #134 