### PR TITLE
[Feat] 유저 프로필 수정 페이지 기능 구현 

### DIFF
--- a/src/API/api.js
+++ b/src/API/api.js
@@ -204,3 +204,13 @@ export const deleteProduct = async productId => {
     throw new Error(error);
   }
 };
+
+export const editProfile = async () => {
+  try {
+    const response = await instance.put(`/user`);
+
+    return response.data;
+  } catch (error) {
+    return new Error(error);
+  }
+};

--- a/src/Components/Common/Header/Header.jsx
+++ b/src/Components/Common/Header/Header.jsx
@@ -54,7 +54,7 @@ export default function Header() {
   const listObj = [
     {
       name: '설정 및 개인정보',
-      func: () => console.log('설정 및 개인정보'),
+      func: () => navigate('/profile/:accountname/edit'),
     },
     {
       name: '로그아웃',

--- a/src/Components/Common/Header/Header.jsx
+++ b/src/Components/Common/Header/Header.jsx
@@ -54,7 +54,11 @@ export default function Header() {
   const listObj = [
     {
       name: '설정 및 개인정보',
-      func: () => navigate('/profile/:accountname/edit'),
+      func: () => {
+        const accountname = localStorage.getItem('user ID');
+
+        navigate(`/profile/${accountname}/edit`);
+      },
     },
     {
       name: '로그아웃',

--- a/src/Components/Common/Header/Header.style.jsx
+++ b/src/Components/Common/Header/Header.style.jsx
@@ -18,9 +18,6 @@ export const Div = styled.div`
   }
 
   button {
-    background-color: transparent;
-    border: none;
-    cursor: pointer;
     img {
       width: 24px;
     }

--- a/src/Components/Common/PostAlbum/PostAlbum.jsx
+++ b/src/Components/Common/PostAlbum/PostAlbum.jsx
@@ -1,9 +1,11 @@
 import React, { useState, useEffect } from 'react';
+import { Link } from 'react-router-dom';
 import { PostAlbumWrapper, AlbumImgItem } from './PostAlbum.style';
 import Iconlayers from './../../../Assets/Icons/icon_layers.png';
 
-export default function PostAlbum({ postImg }) {
+export default function PostAlbum({ postImg, postDetail }) {
   const [img, setImg] = useState([]);
+  const id = postDetail;
 
   useEffect(() => {
     if (!postImg) {
@@ -21,26 +23,30 @@ export default function PostAlbum({ postImg }) {
       <PostAlbumWrapper>
         {postImg &&
           (img.length > 1 ? (
-            <AlbumImgItem>
-              <img
-                className='multiImage'
-                src={`https://mandarin.api.weniv.co.kr/${img[0]}`}
-                alt='사용자가 업로드한 이미지'
-              />
-              <img
-                className='layerIcon'
-                src={Iconlayers}
-                alt='사용자가 업로드한 이미지가 여러 개인 것을 알려주는 아이콘'
-              />
-            </AlbumImgItem>
+            <Link to={`/post/${id}`}>
+              <AlbumImgItem>
+                <img
+                  className='multiImage'
+                  src={`https://mandarin.api.weniv.co.kr/${img[0]}`}
+                  alt='사용자가 업로드한 이미지'
+                />
+                <img
+                  className='layerIcon'
+                  src={Iconlayers}
+                  alt='사용자가 업로드한 이미지가 여러 개인 것을 알려주는 아이콘'
+                />
+              </AlbumImgItem>
+            </Link>
           ) : (
-            <AlbumImgItem>
-              <img
-                className='multiImage'
-                src={`https://mandarin.api.weniv.co.kr/${img[0]}`}
-                alt='사용자가 업로드한 이미지'
-              />
-            </AlbumImgItem>
+            <Link to={`/post/${id}`}>
+              <AlbumImgItem>
+                <img
+                  className='multiImage'
+                  src={`https://mandarin.api.weniv.co.kr/${img[0]}`}
+                  alt='사용자가 업로드한 이미지'
+                />
+              </AlbumImgItem>
+            </Link>
           ))}
       </PostAlbumWrapper>
     </>

--- a/src/Components/ProfileEdit/ProfileImg/ProfileImg.jsx
+++ b/src/Components/ProfileEdit/ProfileImg/ProfileImg.jsx
@@ -3,11 +3,11 @@ import { ProfileImgWrapper } from './ProfileImg.style';
 import ProfileThumb from '../../Common/ProfileThumb/ProfileThumb';
 import BtnUpload from '../../Common/BtnUpload/BtnUpload';
 
-export default function ProfileImg({ stateFunc, state }) {
+export default function ProfileImg({ stateFunc, state, src }) {
   return (
     <>
       <ProfileImgWrapper>
-        <ProfileThumb size='xlarge' src={`https://mandarin.api.weniv.co.kr/${state}`} />
+        <ProfileThumb size='xlarge' src={src} />
         <BtnUpload stateFunc={stateFunc} response={state} />
       </ProfileImgWrapper>
     </>

--- a/src/Pages/Main/Profile/ProfileEdit/ProfileEdit.jsx
+++ b/src/Pages/Main/Profile/ProfileEdit/ProfileEdit.jsx
@@ -4,7 +4,7 @@ import { useLocation, useNavigate } from 'react-router-dom';
 import { useUploadFile } from './../../../../Hooks/useUploadFile';
 import ProfileImg from '../../../../Components/ProfileEdit/ProfileImg/ProfileImg';
 import { ProfileWrapper, InputWrapper, Label, Input, InpImg, ErrorMessage } from './ProfileEdit.style';
-import { editProfile } from '../../../../API/api';
+import { editProfile, getProfile } from '../../../../API/api';
 
 // const idAxios = axios.create({
 //   baseURL: 'https://mandarin.api.weniv.co.kr/user',
@@ -24,10 +24,22 @@ export default function ProfileEdit() {
   const [userName, setUserName] = useState('');
   const [userId, setUserId] = useState('');
   const [userIntro, setUserIntro] = useState('');
+  const [profileImg, setProfileImg] = useState('');
 
   const [userNameError, setUserNameError] = useState('');
   const [userIdError, setUserIdError] = useState('');
-  const [isBtnActive, setIsBtnActive] = useState(true);
+  // const [isBtnActive, setIsBtnActive] = useState(true);
+
+  useEffect(() => {
+    getProfile(process.env.REACT_APP_ACCOUNT_NAME).then(res => {
+      const { accountname, username, intro, image } = res.profile;
+
+      setUserId(prev => username);
+      setUserName(prev => accountname);
+      setUserIntro(prev => intro);
+      setProfileImg(prev => image);
+    });
+  }, []);
 
   // 사용자이름 유효성 검사
   const userNameValidation = e => {
@@ -71,17 +83,17 @@ export default function ProfileEdit() {
     }
   };
 
-  useEffect(() => {
-    if (!userNameError && !userIdError) {
-      if (!!userName && !!userId) {
-        setIsBtnActive(prev => false);
-      } else {
-        setIsBtnActive(prev => true);
-      }
-    } else {
-      setIsBtnActive(prev => true);
-    }
-  }, [userId, userName, userNameError, userIdError]);
+  // useEffect(() => {
+  //   if (!userNameError && !userIdError) {
+  //     if (!!userName && !!userId) {
+  //       setIsBtnActive(prev => false);
+  //     } else {
+  //       setIsBtnActive(prev => true);
+  //     }
+  //   } else {
+  //     setIsBtnActive(prev => true);
+  //   }
+  // }, [userId, userName, userNameError, userIdError]);
 
   const submitProfile = async e => {
     e.preventDefault();
@@ -127,7 +139,7 @@ export default function ProfileEdit() {
     <ProfileWrapper>
       <form onSubmit={submitProfile} id='profileContent'>
         <InpImg>
-          <ProfileImg userName={userName} state={response} stateFunc={uploadSingleFile} />
+          <ProfileImg userName={userName} state={response} stateFunc={uploadSingleFile} src={profileImg} />
         </InpImg>
         <InputWrapper>
           <Label htmlFor='userName'>사용자 이름</Label>
@@ -136,6 +148,7 @@ export default function ProfileEdit() {
             onChange={userNameValidation}
             type='text'
             placeholder='2~10자 이내여야 합니다.'
+            value={userName}
             required
           />
           <ErrorMessage>{userNameError}</ErrorMessage>
@@ -147,6 +160,7 @@ export default function ProfileEdit() {
             type='text'
             onChange={userIdValidation}
             placeholder='영문, 숫자, 특수문자(.),(_)만 사용 가능합니다.'
+            value={userId}
             required
           />
           <ErrorMessage>{userIdError}</ErrorMessage>
@@ -158,6 +172,7 @@ export default function ProfileEdit() {
             type='text'
             onChange={userIntroCheck}
             placeholder='자신과 판매할 상품에 대해 소개해 주세요!'
+            value={userIntro}
           />
         </InputWrapper>
         {/* <Button className='large' content='시작하기' disabled={isBtnActive} formName='profileContent' /> */}

--- a/src/Pages/Main/Profile/ProfileEdit/ProfileEdit.jsx
+++ b/src/Pages/Main/Profile/ProfileEdit/ProfileEdit.jsx
@@ -1,13 +1,167 @@
-import React from 'react';
+import axios from 'axios';
+import React, { useEffect, useState } from 'react';
+import { useLocation, useNavigate } from 'react-router-dom';
+import { useUploadFile } from './../../../../Hooks/useUploadFile';
 import ProfileImg from '../../../../Components/ProfileEdit/ProfileImg/ProfileImg';
-import ProfileInput from '../../../../Components/ProfileEdit/ProfileInput/ProfileInput';
-import { ProfileEditWrapper } from './ProfileEdit.style';
+import { ProfileWrapper, InputWrapper, Label, Input, InpImg, ErrorMessage } from './ProfileEdit.style';
+import { editProfile } from '../../../../API/api';
+
+// const idAxios = axios.create({
+//   baseURL: 'https://mandarin.api.weniv.co.kr/user',
+//   headers: { 'Content-type': 'application/json' },
+// });
+
+// const editAxios = axios.create({
+//   baseURL: 'https://mandarin.api.weniv.co.kr/',
+//   headers: { 'Content-type': 'application/json' },
+// });
 
 export default function ProfileEdit() {
+  const { uploadSingleFile, response } = useUploadFile();
+  const navigate = useNavigate();
+  const location = useLocation();
+
+  const [userName, setUserName] = useState('');
+  const [userId, setUserId] = useState('');
+  const [userIntro, setUserIntro] = useState('');
+
+  const [userNameError, setUserNameError] = useState('');
+  const [userIdError, setUserIdError] = useState('');
+  const [isBtnActive, setIsBtnActive] = useState(true);
+
+  // 사용자이름 유효성 검사
+  const userNameValidation = e => {
+    const value = e.target.value;
+
+    setUserName(prev => value);
+
+    if ((value.length < 2 && value !== '') || value.length > 10) {
+      setUserNameError('2~10자 이내여야 합니다.');
+    } else if (value === '') {
+      setUserNameError('사용자 이름을 입력해주세요.');
+    } else {
+      setUserNameError('');
+    }
+  };
+
+  // 계정 ID 유효성 검사
+  const userIdValidation = e => {
+    const value = e.target.value;
+    const userIdRegex = /^[_A-Za-z0-9.]*$/;
+
+    setUserId(prev => value);
+
+    if (!userIdRegex.test(value)) {
+      setUserIdError('영문, 숫자, 특수문자(,),(_)만 사용가능합니다.');
+    } else if (value === '') {
+      setUserIdError('계정 ID를 입력해주세요.');
+    } else {
+      setUserIdError('');
+    }
+  };
+
+  // 소개 유효성 검사
+  const userIntroCheck = e => {
+    const value = e.target.value;
+
+    if (value === '') {
+      setUserIntro('');
+    } else {
+      setUserIntro(prev => value);
+    }
+  };
+
+  useEffect(() => {
+    if (!userNameError && !userIdError) {
+      if (!!userName && !!userId) {
+        setIsBtnActive(prev => false);
+      } else {
+        setIsBtnActive(prev => true);
+      }
+    } else {
+      setIsBtnActive(prev => true);
+    }
+  }, [userId, userName, userNameError, userIdError]);
+
+  const submitProfile = async e => {
+    e.preventDefault();
+
+    try {
+      const res = await axios.put('/user', {
+        user: {
+          username: userName,
+          accountname: userId,
+          intro: userIntro,
+          image: `https://mandarin.api.weniv.co.kr/${response}`,
+        },
+      });
+
+      if (res.data.message === '사용 가능한 계정ID 입니다.') {
+        console.log(res.data.message);
+        await editProfile();
+      } else if (res.data.message === '이미 가입된 계정ID 입니다.') {
+        console.log(res.data.message);
+      } else if (res.data.message === '잘못된 접근입니다.') {
+        console.log(res.data.message);
+      }
+    } catch (error) {
+      console.log(error.message);
+    }
+  };
+
+  // const submitRegister = async () => {
+  //   try {
+  //     await editAxios
+  //       .post('/user', data)
+  //       .then(res => {
+  //         console.log(res);
+  //         navigate('/home');
+  //       })
+  //       .catch(res => console.log(res.data.message));
+  //   } catch (error) {
+  //     console.log(error.message);
+  //   }
+  // };
+
   return (
-    <ProfileEditWrapper>
-      <ProfileImg />
-      <ProfileInput />
-    </ProfileEditWrapper>
+    <ProfileWrapper>
+      <form onSubmit={submitProfile} id='profileContent'>
+        <InpImg>
+          <ProfileImg userName={userName} state={response} stateFunc={uploadSingleFile} />
+        </InpImg>
+        <InputWrapper>
+          <Label htmlFor='userName'>사용자 이름</Label>
+          <Input
+            id='userName'
+            onChange={userNameValidation}
+            type='text'
+            placeholder='2~10자 이내여야 합니다.'
+            required
+          />
+          <ErrorMessage>{userNameError}</ErrorMessage>
+        </InputWrapper>
+        <InputWrapper>
+          <Label htmlFor='userId'>계정 ID</Label>
+          <Input
+            id='userId'
+            type='text'
+            onChange={userIdValidation}
+            placeholder='영문, 숫자, 특수문자(.),(_)만 사용 가능합니다.'
+            required
+          />
+          <ErrorMessage>{userIdError}</ErrorMessage>
+        </InputWrapper>
+        <InputWrapper>
+          <Label htmlFor='userDesc'>소개</Label>
+          <Input
+            id='userDesc'
+            type='text'
+            onChange={userIntroCheck}
+            placeholder='자신과 판매할 상품에 대해 소개해 주세요!'
+          />
+        </InputWrapper>
+        {/* <Button className='large' content='시작하기' disabled={isBtnActive} formName='profileContent' /> */}
+      </form>
+    </ProfileWrapper>
   );
 }

--- a/src/Pages/Main/Profile/ProfileEdit/ProfileEdit.style.jsx
+++ b/src/Pages/Main/Profile/ProfileEdit/ProfileEdit.style.jsx
@@ -1,7 +1,51 @@
 import styled from 'styled-components';
 
-export const ProfileEditWrapper = styled.section`
+export const ProfileWrapper = styled.div`
+  width: 100%;
+  overflow: hidden;
   display: flex;
   flex-direction: column;
-  margin: 0 34px;
+  align-items: center;
+  height: 100%;
+  overflow-y: auto;
+`;
+
+export const Label = styled.label`
+  margin-bottom: 10px;
+  font-size: ${({ theme }) => theme.fontSizes.sm};
+`;
+
+export const Input = styled.input`
+  font-family: 'SpoqaHanSans', sans-serif;
+  width: 322px;
+  border: none;
+  padding: 10px 5px;
+  font-size: ${({ theme }) => theme.fontSizes.base};
+  border-bottom: 1px solid ${({ theme }) => theme.colors.border};
+  &::placeholder {
+    color: ${({ theme }) => theme.colors.border};
+  }
+
+  &:focus {
+    outline: none;
+    border-bottom: 1px solid ${({ theme }) => theme.colors.primary};
+  }
+`;
+
+export const InputWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  margin-bottom: 40px;
+`;
+
+export const InpImg = styled.div`
+  display: flex;
+  justify-content: center;
+  margin-bottom: 30px;
+`;
+
+export const ErrorMessage = styled.p`
+  font-size: ${({ theme }) => theme.fontSizes.sm};
+  color: ${({ theme }) => theme.colors.warning};
+  margin-top: 6px;
 `;


### PR DESCRIPTION
### 📝 무엇을 위한 PR인가요?

- [x] 기능 추가 : 유저 프로필 수정 페이지 기능 구현, 앨범형 사진 클릭시 PostDetail 페이지로 이동 기능 구현 


### ♻️ 작업내역 / 변경사항

1. API 파일에 editProfile api 추가 
2. profileEdit 페이지에서 기능 구현 
(이 영광을 윤구님께 돌립니다 .. 👀) 
+ 앨범형 사진 클릭시 PostDetail 페이지로 이동 기능 구현 

### 🖼 결과
<img width="444" alt="스크린샷 2022-12-31 오전 3 07 21" src="https://user-images.githubusercontent.com/110231276/210100093-85a3479f-2deb-4a9f-8201-0c8245c8b674.png">

/profile/undefined/edit 로 들어가시면 됩니닷 .. 


### 💡 이슈 번호

#131 