### PR TITLE
[Fix] 홈피드에서 이미지가 없는 게시물이 존재할 시 에러 발생하는 이슈

### DIFF
--- a/src/Pages/Main/HomeFeed/HomeFeed.jsx
+++ b/src/Pages/Main/HomeFeed/HomeFeed.jsx
@@ -23,7 +23,7 @@ export default function HomeFeed() {
     <HomeFeedWrapper length={feedList.length}>
       {feedList.length ? (
         feedList.map(feed => {
-          const postImg = feed.image.split('co.kr/')[1];
+          const postImg = feed.image?.split('co.kr/')[1];
 
           return (
             <PostCard
@@ -36,7 +36,6 @@ export default function HomeFeed() {
               key={crypto.randomUUID()}
             />
           );
-          // <p>d</p>
         })
       ) : (
         <>


### PR DESCRIPTION
### 📝 무엇을 위한 PR인가요?

- [x] 버그 수정 : 홈피드에서 이미지가 없는 게시물이 존재할 시 에러 발생하는 이슈 해결

### ♻️ 작업내역 / 변경사항

1. feed.image 가 존재하는 지 체크

### 🖼 결과

![image](https://user-images.githubusercontent.com/46313348/210128360-f4cfa77e-1795-4b1f-bbb8-e811fa244b98.png)

### 💡 이슈 번호