### PR TITLE
[Bug] 해당 유저의 follower/following 리스트를 불러오도록 수정

### DIFF
--- a/src/API/api.js
+++ b/src/API/api.js
@@ -45,9 +45,9 @@ export const getMyInfo = async () => {
   }
 };
 
-export const getFollowerList = async () => {
+export const getFollowerList = async accountname => {
   try {
-    const response = await instance.get(`/profile/${userAccountName}/follower`);
+    const response = await instance.get(`/profile/${accountname}/follower`);
 
     return response.data;
   } catch (error) {
@@ -56,9 +56,9 @@ export const getFollowerList = async () => {
   }
 };
 
-export const getFollowingList = async () => {
+export const getFollowingList = async accountname => {
   try {
-    const response = await instance.get(`/profile/${userAccountName}/following`);
+    const response = await instance.get(`/profile/${accountname}/following`);
 
     return response.data;
   } catch (error) {

--- a/src/Pages/Main/Profile/Followers/Followers.jsx
+++ b/src/Pages/Main/Profile/Followers/Followers.jsx
@@ -1,13 +1,15 @@
 import React, { useEffect, useState } from 'react';
+import { useParams } from 'react-router-dom';
 import { getFollowerList } from '../../../../API/api';
 import { FollowersWrapper } from './Followers.style';
 import FollowItem from '../../../../Components/FollowItem/FollowItem';
 
 export default function Followers() {
   const [followerList, setFollowerList] = useState();
+  const { accountName } = useParams();
 
   useEffect(() => {
-    getFollowerList().then(response => setFollowerList(response));
+    getFollowerList(accountName).then(response => setFollowerList(response));
   }, []);
 
   return (

--- a/src/Pages/Main/Profile/Following/Following.jsx
+++ b/src/Pages/Main/Profile/Following/Following.jsx
@@ -1,13 +1,15 @@
 import React, { useEffect, useState } from 'react';
+import { useParams } from 'react-router-dom';
 import { FollowingWrapper } from './Following.style';
 import { getFollowingList } from '../../../../API/api';
 import FollowItem from '../../../../Components/FollowItem/FollowItem';
 
 export default function Following() {
   const [followingList, setFollowingList] = useState([]);
+  const { accountName } = useParams();
 
   useEffect(() => {
-    getFollowingList().then(response => setFollowingList(response));
+    getFollowingList(accountName).then(response => setFollowingList(response));
   }, []);
 
   return (


### PR DESCRIPTION
### 📝 무엇을 위한 PR인가요?

- [x] 버그 수정 : 해당 유저의 follower/following 리스트를 불러오도록 수정


### ♻️ 작업내역 / 변경사항

1. useParams() 로 accountName을 체크해서 팔로워 리스트를 보여주도록 수정

### 🖼 결과

![image](https://user-images.githubusercontent.com/46313348/210263837-e79d0496-6882-42ac-add1-5dab2511121a.png)


### 💡 이슈 번호