### PR TITLE
[Feat] PostCard 내 UserInfo 클릭 시 올바른 url로 이동할 수 있도록 수정

### DIFF
--- a/src/Components/Common/PostCard/PostCard.jsx
+++ b/src/Components/Common/PostCard/PostCard.jsx
@@ -54,7 +54,7 @@ export default function PostCard({ accountname, username, image, postContent, po
     <>
       <PostCardWrapper>
         <WriterInfo>
-          <UserInfo size='medium' userInfoList={{ username, image }} text={accountname} />
+          <UserInfo size='medium' userInfoList={{ accountname, username, image }} text={accountname} />
           <button onClick={() => setIsModal(true)}>
             <img src={iconMore} alt='모달창 띄우는 버튼' />
           </button>


### PR DESCRIPTION
### 📝 무엇을 위한 PR인가요?

- [x] 기능 추가 : PostCard 내 UserInfo 클릭 시 올바른 url로 이동할 수 있도록 수정


### ♻️ 작업내역 / 변경사항

1. PostCard 내 UserInfo 에 accountname 정보 추가로 전달

* PostCard 만 수정하면 될 것 같은데, 혹시 놓친게 있다면 말씀부탁드립니다!

### 🖼 결과

![test](https://user-images.githubusercontent.com/46313348/210265906-9c6bce09-4f74-4629-a5d3-7f3a5a8110ac.gif)

### 💡 이슈 번호
close #138