### PR TITLE
[Feat] 게시물 상세 페이지에 판매 중인 상품 추가

### DIFF
--- a/src/Components/Common/PostCard/PostCard.jsx
+++ b/src/Components/Common/PostCard/PostCard.jsx
@@ -1,7 +1,15 @@
 import React, { useEffect, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import UserInfo from '../UserInfo/UserInfo';
-import { PostCardWrapper, WriterInfo, GetText, GetImg, UploadDate } from './PostCard.style';
+import {
+  PostCardWrapper,
+  WriterInfo,
+  GetText,
+  GetImg,
+  UploadDate,
+  PostTagWrapper,
+  PostTagItem,
+} from './PostCard.style';
 
 import iconMore from '../../../Assets/Icons/icon_more_vertical.png';
 import Modal from '../Modal/Modal';
@@ -18,6 +26,7 @@ export default function PostCard({
   postid,
   commentCount,
   deletePostHandler,
+  children,
 }) {
   const urlPostid = useParams();
   const pagePostId = urlPostid.postid;
@@ -57,6 +66,7 @@ export default function PostCard({
   const upload = new Date(uploadDate);
   const date = getFormatDate(upload);
   const [content, setContent] = useState();
+  const [tagList, setTagList] = useState();
 
   useEffect(() => {
     if (postContent) {
@@ -64,6 +74,7 @@ export default function PostCard({
         const contentObj = JSON.parse(postContent);
 
         setContent(contentObj.textValue);
+        setTagList(contentObj.tagList);
       } catch (error) {
         if (error instanceof SyntaxError) {
           setContent(postContent);
@@ -89,6 +100,13 @@ export default function PostCard({
         </WriterInfo>
 
         <div onClick={() => pageNavigate(pagePostId, postid)}>
+          {tagList && (
+            <PostTagWrapper>
+              {tagList.map(tag => (
+                <PostTagItem key={crypto.randomUUID()}>{tag}</PostTagItem>
+              ))}
+            </PostTagWrapper>
+          )}
           <GetText>{content || null}</GetText>
           {postImg &&
             postImg.split(',').map(el => {
@@ -98,6 +116,7 @@ export default function PostCard({
         <ReactionSection postid={postid} commentCount={commentCount} />
 
         <UploadDate>{date}</UploadDate>
+        {children}
       </PostCardWrapper>
       {isModal && <Modal stateFunc={setIsModal} listObj={listObj} />}
       {isAlert && (

--- a/src/Components/Common/PostCard/PostCard.style.jsx
+++ b/src/Components/Common/PostCard/PostCard.style.jsx
@@ -3,6 +3,13 @@ import styled from 'styled-components';
 export const PostCardWrapper = styled.section`
   padding-bottom: 27px;
   background-color: #fff;
+
+  & > section {
+    margin-top: 20px;
+    padding-left: 65px;
+    padding-bottom: 0;
+    border-top: 1px solid ${({ theme }) => theme.colors.border};
+  }
 `;
 
 export const WriterInfo = styled.div`
@@ -31,4 +38,43 @@ export const UploadDate = styled.span`
   padding-left: 65px;
   font-size: ${({ theme }) => theme.fontSizes.sm};
   color: ${({ theme }) => theme.colors.subText};
+`;
+
+export const PostTagWrapper = styled.ul`
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 4px;
+  padding: 0px 20px 16px 65px;
+
+  input {
+    flex: 1 1 auto;
+    line-height: 26px;
+    padding: 0;
+    border: none;
+    outline: none;
+    font-size: ${({ theme }) => theme.fontSizes.base};
+    font-family: 'SpoqaHanSans', sans-serif;
+
+    &::placeholder {
+      color: ${({ theme }) => theme.colors.placeholder};
+    }
+  }
+`;
+
+export const PostTagItem = styled.li`
+  display: flex;
+  align-items: center;
+  gap: 2px;
+  line-height: 24px;
+  padding: 0 8px;
+  border-radius: 26px;
+  border: 1px solid ${({ theme }) => theme.colors.border};
+  word-break: keep-all;
+  font-size: ${({ theme }) => theme.fontSizes.sm};
+
+  img {
+    width: 14px;
+    height: 14px;
+  }
 `;

--- a/src/Pages/Post/PostDetail/PostDetail.jsx
+++ b/src/Pages/Post/PostDetail/PostDetail.jsx
@@ -3,16 +3,27 @@ import { useParams } from 'react-router-dom';
 import Comment from '../../../Components/Comment/Comment';
 import PostCard from '../../../Components/Common/PostCard/PostCard';
 import { getPostDetail } from '../../../API/api';
+import Product from './../../../Components/Product/Product';
 
 export default function PostDetail() {
   const { postid } = useParams();
   const [isRender, setIsRender] = useState(false);
 
   const [postDetail, setPostDetail] = useState();
+  const [tagList, setTagList] = useState([]);
 
   useEffect(() => {
     getPostDetail(postid).then(response => {
       setPostDetail(prev => response);
+      try {
+        const contentObj = JSON.parse(response.post.content);
+
+        setTagList(contentObj.tagList || []);
+      } catch (error) {
+        if (error instanceof SyntaxError) {
+          setTagList([]);
+        }
+      }
     });
     setIsRender(true);
   }, []);
@@ -31,7 +42,9 @@ export default function PostDetail() {
           key={crypto.randomUUID()}
           commentCount={postDetail.post.commentCount}
           postid={postDetail.post.id}
-        />
+        >
+          <Product accountName={postDetail.post.author.accountname} tagList={tagList} />
+        </PostCard>
         <Comment />
       </>
     )


### PR DESCRIPTION
### 📝 무엇을 위한 PR인가요?

- [x] 기능 추가 : 게시물 상세 페이지에 판매 중인 상품 추가

### ♻️ 작업내역 / 변경사항

1. 게시물 상세 페이지 내 판매 중인 상품 컴포넌트 추가
2. 게시물 내 재료 상태에 따라 판매 중인 상품 필터링
3. ProductCard 컴포넌트에 재료란 추가

### 🖼 결과

![image](https://user-images.githubusercontent.com/46313348/210397966-04489764-eb26-468a-9a92-95f6f7ad2db5.png)

### 💡 이슈 번호
close #159