### PR TITLE
[Fix] comment Input user Image 추가

### DIFF
--- a/src/Components/CommentItem/MyCommentInput.jsx
+++ b/src/Components/CommentItem/MyCommentInput.jsx
@@ -1,15 +1,19 @@
 import React, { useEffect, useState } from 'react';
 import { useParams } from 'react-router-dom';
 import { CommentInputBox, CommentInput, UserWrapper } from './MyCommentInput.style';
-import { uploadComment } from '../../API/api';
+import { uploadComment, getMyInfo } from '../../API/api';
 import ProfileThumb from '../Common/ProfileThumb/ProfileThumb';
 import Button from '../Common/Button/Button';
 
 export function MyCommentInput({ stateFunc }) {
   const { postid } = useParams();
-
+  const [userImg, setUserImg] = useState('');
   const [inputValue, setInputValue] = useState('');
   const [isButtonEnabled, setButtonEnabled] = useState('');
+
+  useEffect(() => {
+    getMyInfo().then(res => setUserImg(res.user.image));
+  });
 
   const onChangeKeyword = e => {
     const value = e.target.value;
@@ -41,7 +45,7 @@ export function MyCommentInput({ stateFunc }) {
   return (
     <CommentInputBox onSubmit={commentInput}>
       <UserWrapper>
-        <ProfileThumb size='small' />
+        <ProfileThumb src={userImg} size='small' />
         <CommentInput placeholder='댓글 입력하기' onChange={onChangeKeyword} value={inputValue} />
       </UserWrapper>
       <Button className='small' content='게시' disabled={isButtonEnabled} />


### PR DESCRIPTION
### 📝 무엇을 위한 PR인가요?


- [x] 버그 수정 : comment input 컴포넌트에 유저 이미지 추가


### ♻️ 작업내역 / 변경사항

1. api를 통해 유저 정보를 불러옵니다.

2. 유저 정보의 이미지를 컴포넌트에 넣어줍니다.


### 🖼 결과
<img width="813" alt="스크린샷 2023-01-04 03 18 45" src="https://user-images.githubusercontent.com/78248971/210418092-9a5e4921-4426-4347-a48e-69f71917e488.png">

### 💡 이슈 번호
close #165 