### PR TITLE
[Fix] 게시글 상세 페이지에 삭제 기능 추가

### DIFF
--- a/src/Pages/Post/PostDetail/PostDetail.jsx
+++ b/src/Pages/Post/PostDetail/PostDetail.jsx
@@ -1,8 +1,8 @@
 import React, { useState, useEffect } from 'react';
-import { useParams } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router-dom';
 import Comment from '../../../Components/Comment/Comment';
 import PostCard from '../../../Components/Common/PostCard/PostCard';
-import { getPostDetail } from '../../../API/api';
+import { deletePost, getPostDetail } from '../../../API/api';
 import Product from './../../../Components/Product/Product';
 
 export default function PostDetail() {
@@ -11,6 +11,15 @@ export default function PostDetail() {
 
   const [postDetail, setPostDetail] = useState();
   const [tagList, setTagList] = useState([]);
+
+  const navigate = useNavigate();
+
+  const deletePostHandler = () => {
+    const { accountname } = postDetail.post.author;
+
+    deletePost(postid);
+    navigate(`/profile/${accountname}`);
+  };
 
   useEffect(() => {
     getPostDetail(postid).then(response => {
@@ -42,6 +51,7 @@ export default function PostDetail() {
           key={crypto.randomUUID()}
           commentCount={postDetail.post.commentCount}
           postid={postDetail.post.id}
+          deletePostHandler={deletePostHandler}
         >
           <Product accountName={postDetail.post.author.accountname} tagList={tagList} />
           <Comment />


### PR DESCRIPTION
### 📝 무엇을 위한 PR인가요?

- [x] 버그 수정 : 게시글 상세 페이지에서 삭제 기능이 동작하지 않는 문제

### ♻️ 작업내역 / 변경사항

1. 게시글 상세 페이지에 deletePostHandler 함수 추가

2. 게시글 상세 페이지에서 게시글 삭제 시 유저 프로필 페이지로 이동하도록 navigate 추가


### 🖼 결과
![test](https://user-images.githubusercontent.com/46313348/214243408-cd2ba9c5-160c-4e68-8371-2319b63fa2d0.gif)
게시글 상세 페이지에서도 삭제 기능이 동작합니다.

### 💡 이슈 번호
close  #189