### PR TITLE
[Fix] 프로필 이미지가 제대로 로드되지 않는 오류 수정

### DIFF
--- a/src/Components/Common/ProfileThumb/ProfileThumb.jsx
+++ b/src/Components/Common/ProfileThumb/ProfileThumb.jsx
@@ -1,10 +1,15 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { ProfileThumbWrapper } from './ProfileThumb.style';
+import userDefalutImage from '../../../Assets/Images/img_profile_basic.png';
 
-export default function ProfileThumb({ src = [], userName, size }) {
+export default function ProfileThumb({ src, userName, size }) {
+  const [imgSrc, setImgSrc] = useState(src);
+
+  const handleError = () => setImgSrc(userDefalutImage);
+
   return (
-    <ProfileThumbWrapper src={src} size={size}>
-      {!!src.length && <img src={src} alt={userName} />}
+    <ProfileThumbWrapper src={imgSrc} size={size}>
+      {!!src.length && <img src={imgSrc} alt={userName} onError={handleError} />}
     </ProfileThumbWrapper>
   );
 }

--- a/src/Components/Search/SearchUserItem.jsx
+++ b/src/Components/Search/SearchUserItem.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { UserWrapper } from './SearchUserItem.style';
 import UserInfo from '../Common/UserInfo/UserInfo';
 
-export default function SearchUserItem({ userName = '', userId = '', userImage = '', text }) {
+export default function SearchUserItem({ userName = '', userId = '', userImage = '' }) {
   return (
     <UserWrapper>
       <UserInfo


### PR DESCRIPTION
### 📝 무엇을 위한 PR인가요?

- [x] 버그 수정 : 기본 이미지 경로가 적절하지 않을 경우 유저 검색창, 유저 프로필, 게시물 등에서 이미지가 제대로 불러와지지 않는 오류 수정


### ♻️ 작업내역 / 변경사항
ProfileThumb.jsx 파일에 onError, handleError 코드 추가

### 🖼 결과
<img width="547" alt="image" src="https://user-images.githubusercontent.com/55517023/214545095-d98a91c1-ccc8-4978-8dd8-d86ee1b041a9.png">
<img width="572" alt="image" src="https://user-images.githubusercontent.com/55517023/214545014-9eb58521-7229-4eea-a962-1308f5a74cf9.png">

### 💡 이슈 번호
close #203 