### PR TITLE
[Fix] 375px 에서 모달이 잘려보이는 문제 해결

### DIFF
--- a/src/Components/Common/Modal/Modal.style.jsx
+++ b/src/Components/Common/Modal/Modal.style.jsx
@@ -35,7 +35,8 @@ export const ModalWrapper = styled.div`
   left: 50%;
   background-color: ${({ theme }) => theme.colors.ground};
   transform: translate(-50%);
-  width: 390px;
+  max-width: 390px;
+  width: 100%;
   padding: 36px 2px 10px 2px;
   border-radius: 10px 10px 0 0;
   animation: ${slideUp} 0.5s;


### PR DESCRIPTION
### 📝 무엇을 위한 PR인가요?

- [x] 버그 수정 : 375px 에서 모달이 잘려보이는 문제 해결

### ♻️ 작업내역 / 변경사항

1. 모달이 최대 가로 390px 사이즈를 가지도록 수정

### 🖼 결과

390px 이하의 스크린 사이즈에서는 모달이 100%의 가로사이즈를 가집니다.

### 💡 이슈 번호
#190