### PR TITLE
[Fix] 프로필 페이지에서 유저 이미지가 안 보이는 문제 해결

### DIFF
--- a/src/Components/Common/ProfileThumb/ProfileThumb.jsx
+++ b/src/Components/Common/ProfileThumb/ProfileThumb.jsx
@@ -1,15 +1,17 @@
 import React, { useState } from 'react';
 import { ProfileThumbWrapper } from './ProfileThumb.style';
-import userDefalutImage from '../../../Assets/Images/img_profile_basic.png';
+import userDefaultImage from '../../../Assets/Images/img_profile_basic.png';
 
 export default function ProfileThumb({ src, userName, size }) {
   const [imgSrc, setImgSrc] = useState(src);
 
-  const handleError = () => setImgSrc(userDefalutImage);
+  const handleError = () => {
+    setImgSrc(userDefaultImage);
+  };
 
   return (
-    <ProfileThumbWrapper src={imgSrc} size={size}>
-      {!!src.length && <img src={imgSrc} alt={userName} onError={handleError} />}
+    <ProfileThumbWrapper source={src} size={size}>
+      <img src={imgSrc} alt={userName} onError={handleError} />
     </ProfileThumbWrapper>
   );
 }

--- a/src/Components/Common/ProfileThumb/ProfileThumb.style.jsx
+++ b/src/Components/Common/ProfileThumb/ProfileThumb.style.jsx
@@ -29,7 +29,7 @@ export const ProfileThumbWrapper = styled.div`
   position: relative;
   border-radius: 50%;
   box-sizing: border-box;
-  ${({ src }) => !src.length && `background: url(${basicProfileImage}) no-repeat center / calc(100% + 2px) auto;`}
+  ${({ source }) => source && `background: url(${basicProfileImage}) no-repeat center / calc(100% + 2px) auto;`}
   overflow: hidden;
   border: 1px solid ${({ theme }) => theme.colors.border};
 

--- a/src/Pages/Main/Profile/UserProfile/UserProfile.jsx
+++ b/src/Pages/Main/Profile/UserProfile/UserProfile.jsx
@@ -80,7 +80,7 @@ export default function UserProfile() {
                 <p>followers</p>
               </Link>
             </Followers>
-            <ProfileThumb size='xlarge' src={profileImg} />
+            {profileImg && <ProfileThumb size='xlarge' src={profileImg} />}
             <Followings>
               <Link to={`/profile/${userId}/following`}>
                 <strong>{following}</strong>


### PR DESCRIPTION
### 📝 무엇을 위한 PR인가요?

- [x] 버그 수정 : 프로필 페이지와 댓글에서 유저 이미지가 안 보이는 문제 해결

### ♻️ 작업내역 / 변경사항

1. 유저 이미지 데이터가 로드되었는지 체크

2. ProfileThumb 컴포넌트의 div 요소에서 src 속성 삭제


### 🖼 결과

<img width="383" alt="스크린샷 2023-01-26 오후 6 49 26" src="https://user-images.githubusercontent.com/46313348/214818920-2ab1a45b-19dc-408b-878e-d7bf1184f8b5.png">

등록한 유저 이미지가 정상적으로 보여집니다

### 💡 이슈 번호
close #211 